### PR TITLE
add recipe to build v2024.04 u-boot, and some minor clean up

### DIFF
--- a/conf/machine/beagleplay-dev-k3r5.conf
+++ b/conf/machine/beagleplay-dev-k3r5.conf
@@ -4,16 +4,11 @@
 
 require conf/machine/include/k3r5.inc
 
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-bb.org"
-PREFERRED_PROVIDER_u-boot = "u-boot-bb.org"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-beagleplay-dev"
+PREFERRED_PROVIDER_u-boot = "u-boot-beagleplay-dev"
 
 SYSFW_SOC = "am62x"
 SYSFW_CONFIG = "evm"
 SYSFW_SUFFIX = "gp"
 
-UBOOT_MACHINE = "am62x_evm_r5_defconfig"
-
-# UBOOT_CONFIG_FRAGMENTS holds the list of u-boot config fragments which has to be build
-# along with the base defconfig mentioned in UBOOT_MACHINE. Refer u-boot-mergeconfig.inc
-# under meta-ti-bsp/recipes-bsp/u-boot/ for more details.
-UBOOT_CONFIG_FRAGMENTS = "am625_beagleplay_r5.config"
+UBOOT_MACHINE = "am62x_beagleplay_r5_defconfig"

--- a/conf/machine/beagleplay-dev.conf
+++ b/conf/machine/beagleplay-dev.conf
@@ -1,4 +1,4 @@
-require conf/machine//include/beagle.inc
+require conf/machine/include/beagle.inc
 require conf/machine/include/k3.inc
 
 SERIAL_CONSOLES = "115200;ttyS2"
@@ -10,16 +10,11 @@ TFA_K3_SYSTEM_SUSPEND = "1"
 
 OPTEEMACHINE = "k3-am62x"
 
-UBOOT_MACHINE = "am62x_evm_a53_defconfig"
-
-# UBOOT_CONFIG_FRAGMENTS holds the list of u-boot config fragments which has to be build
-# along with the base defconfig mentioned in UBOOT_MACHINE. Refer u-boot-mergeconfig.inc
-# under meta-ti-bsp/recipes-bsp/u-boot/ for more details.
-UBOOT_CONFIG_FRAGMENTS = "am625_beagleplay_a53.config"
+UBOOT_MACHINE = "am62x_beagleplay_a53_defconfig"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-beagleplay-dev"
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-bb.org"
-PREFERRED_PROVIDER_u-boot = "u-boot-bb.org"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-beagleplay-dev"
+PREFERRED_PROVIDER_u-boot = "u-boot-beagleplay-dev"
 
 KERNEL_DEVICETREE_PREFIX = " \
     ti/k3-am625 \

--- a/recipes-bsp/u-boot/files/0001-update-bootcmd-beagleplay-dev.patch
+++ b/recipes-bsp/u-boot/files/0001-update-bootcmd-beagleplay-dev.patch
@@ -1,0 +1,26 @@
+diff --git a/configs/am62x_beagleplay_a53_defconfig b/configs/am62x_beagleplay_a53_defconfig
+index 470095e8d3..cbd3a61cf4 100644
+--- a/configs/am62x_beagleplay_a53_defconfig
++++ b/configs/am62x_beagleplay_a53_defconfig
+@@ -32,7 +32,7 @@ CONFIG_AUTOBOOT_KEYED=y
+ CONFIG_AUTOBOOT_PROMPT="Press SPACE to abort autoboot in %d seconds\n"
+ CONFIG_AUTOBOOT_DELAY_STR="d"
+ CONFIG_AUTOBOOT_STOP_STR=" "
+-CONFIG_BOOTCOMMAND="run set_led_state_start_load; run envboot; bootflow scan -lb;run set_led_state_fail_load"
++CONFIG_BOOTCOMMAND="run set_led_state_start_load; fatload mmc 1:1 0x80000000 Image; fatload mmc 1:1 0x92000000 k3-am625-beagleplay.dtb; booti 0x80000000 - 0x92000000; run set_led_state_fail_load"
+ CONFIG_BOARD_LATE_INIT=y
+ CONFIG_SPL_MAX_SIZE=0x58000
+ CONFIG_SPL_HAS_BSS_LINKER_SECTION=y
+@@ -116,3 +116,12 @@ CONFIG_SYSRESET_TI_SCI=y
+ CONFIG_EXT4_WRITE=y
+ CONFIG_FS_FAT_MAX_CLUSTSIZE=16384
+ CONFIG_LZO=y
++CONFIG_ENV_SUPPORT=y
++CONFIG_CMD_SAVEENV=y
++CONFIG_SAVEENV=y
++CONFIG_ENV_MIN_ENTRIES=64
++CONFIG_ENV_MAX_ENTRIES=512
++CONFIG_ENV_IS_IN_EXT4=y
++CONFIG_ENV_EXT4_INTERFACE="mmc"
++CONFIG_ENV_EXT4_DEVICE_AND_PART="1:2"
++CONFIG_ENV_EXT4_FILE="/boot/u-boot-env.bin"

--- a/recipes-bsp/u-boot/u-boot-beagleplay-dev.bb
+++ b/recipes-bsp/u-boot/u-boot-beagleplay-dev.bb
@@ -1,0 +1,31 @@
+require recipes-bsp/u-boot/u-boot-ti.inc
+
+PR = "r0"
+
+PV = "2024.04"
+
+SRC_URI += "file://0001-update-bootcmd-beagleplay-dev.patch"
+
+# For the un-initiated:
+# The actual URL you'd use with a git clone for example would be:
+# https://source.denx.de/u-boot/u-boot.git/
+# However, in the context of OE, we have to explicitly split things up:
+# a) we want it to use git fetcher - hence git:// prefix in GIT_URI (if we
+#  used https here, we'd endup attempting wget instead of git)
+# b) and we want git fetcher to use https protocol, hence GIT_PROTOCOL as https
+UBOOT_GIT_URI = "git://source.denx.de/u-boot/u-boot.git"
+UBOOT_GIT_PROTOCOL = "https"
+SRCREV = "25049ad560826f7dc1c4740883b0016014a59789"
+
+do_create_tispl_bin_symlink() {
+    if [ -e ${B}/tispl.bin_unsigned ]; then
+        ln -sf ${B}/tispl.bin_unsigned ${B}/tispl.bin
+    else
+        echo "Source file does not exist: ${B}/tispl.bin_unsigned"
+        exit 1
+    fi
+}
+
+addtask do_create_tispl_bin_symlink before do_install after do_compile
+
+# do_install[depends] += "u-boot-beagleplay-dev:do_create_tispl_bin_symlink"

--- a/recipes-bsp/u-boot/u-boot-beagleplay-dev.bb
+++ b/recipes-bsp/u-boot/u-boot-beagleplay-dev.bb
@@ -27,5 +27,3 @@ do_create_tispl_bin_symlink() {
 }
 
 addtask do_create_tispl_bin_symlink before do_install after do_compile
-
-# do_install[depends] += "u-boot-beagleplay-dev:do_create_tispl_bin_symlink"

--- a/recipes-core/images/core-image-minimal.bbappend
+++ b/recipes-core/images/core-image-minimal.bbappend
@@ -1,5 +1,5 @@
 inherit extrausers
 EXTRA_USERS_PARAMS = "usermod -p '\$1\$HhsG6ibe\$welFXCf1sirIa/p6eTmsO1' root;"
 
-IMAGE_FSTYPES = "ext4"
+IMAGE_FSTYPES += "ext4"
 IMAGE_INSTALL:append = "packagegroup-core-ssh-openssh u-boot-env bash iiotest drmtest pong bmi270-mod sharp-mod"


### PR DESCRIPTION
this will need to be merged before i PR to beagleplay-dev repo to update to the resulting git commit for the submodule.

this pr is to give the ability to write tiboot3.bin to flash and have it boot tispl.bin and u-boot.img from boot0 of the emmc