### PR TITLE
u-boot-beagleplay-dev.bb updates to help with ti ccs debugging

### DIFF
--- a/recipes-bsp/u-boot/u-boot-beagleplay-dev.bb
+++ b/recipes-bsp/u-boot/u-boot-beagleplay-dev.bb
@@ -19,4 +19,20 @@ do_create_tispl_bin_symlink() {
     fi
 }
 
+do_create_u_boot_elf_symlink() {
+    if [ -e ${B}/u-boot ]; then
+        ln -sf ${B}/u-boot ${B}/u-boot.elf
+    else
+        echo "Source file does not exist: ${B}/u-boot"
+        exit 1
+    fi
+}
+
+do_deploy:append(){
+    if [ -e ${B}/u-boot.elf ]; then
+        install -D -m 644 ${B}/u-boot.elf ${DEPLOYDIR}/u-boot.elf
+    fi
+}
+
 addtask do_create_tispl_bin_symlink before do_install after do_compile
+addtask do_create_u_boot_elf_symlink before do_install after do_compile


### PR DESCRIPTION
create symlink u-boot.elf to u-boot (the elf), and deploy them to deloy dir. this helps with using ti ccs program because it looks for .elf file extension